### PR TITLE
Partial evaulation

### DIFF
--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -74,6 +74,7 @@ fn run_authorize_test_with_linked_policies(
         entities_file: entities_file.into(),
         verbose: true,
         timing: false,
+        partial: false,
     };
     let output = authorize(&cmd);
     assert_eq!(exit_code, output, "{:#?}", cmd,);
@@ -133,6 +134,7 @@ fn run_authorize_test_context(
         entities_file: entities_file.into(),
         verbose: true,
         timing: false,
+        partial: false,
     };
     let output = authorize(&cmd);
     assert_eq!(exit_code, output, "{:#?}", cmd,);
@@ -158,6 +160,7 @@ fn run_authorize_test_json(
         entities_file: entities_file.into(),
         verbose: true,
         timing: false,
+        partial: false,
     };
     let output = authorize(&cmd);
     assert_eq!(exit_code, output, "{:#?}", cmd,);


### PR DESCRIPTION

Introduce an optional parameter "--partial" in the CLI, so to change the entity mode to partial and be able to do partial authorization and give residual result.

Example of when missing principal in the request:

In default mode:
```
while evaluating policy prototypes access policy, encountered the following error: cannot access attribute of unspecified entity: department
```

In partial mode:

```
while evaluating policy prototypes access policy, encountered the following error: The expression evaluated to a residual: true && (true && (((unknown(<Unspecified>::"principal")["department"]) == "HardwareEngineering") && (5 <= (unknown(<Unspecified>::"principal")["jobLevel"]))))
```